### PR TITLE
Adding rails specific config file for reek

### DIFF
--- a/ruby/rails/config.reek
+++ b/ruby/rails/config.reek
@@ -1,0 +1,25 @@
+---
+
+Attribute:
+  enabled: true
+
+TooManyStatements:
+  enabled: false
+
+"app/controllers":
+  IrresponsibleModule:
+    enabled: false
+  NestedIterators:
+    max_allowed_nesting: 2
+  UnusedPrivateMethod:
+    enabled: false
+  InstanceVariableAssumption:
+    enabled: false
+"app/helpers":
+  IrresponsibleModule:
+    enabled: false
+  UtilityFunction:
+    enabled: false
+"app/mailers":
+  InstanceVariableAssumption:
+    enabled: false


### PR DESCRIPTION
Based on reek's documentation, there are suggested settings for Rails
that we don't use: https://github.com/troessner/reek#working-with-rails

Things like instance variables in controllers, for example. Cancancan
provides us with them, and rails controllers have specific flows like
before hooks that make reek think variables might not be set.