### PR TITLE
Migrate Jarvis Rubocop exclusions

### DIFF
--- a/ruby/rails/codeclimate.yml
+++ b/ruby/rails/codeclimate.yml
@@ -44,11 +44,6 @@ engines:
     exclude_fingerprints:
     - 0f4a1f6ee03afcbc0debef591d8d01d9
     - fbcc01d30bd7cf916e9c57a968a2aac5
-    checks:
-      Rubocop/Metrics/ParameterLists:
-        enabled: false
-      Rubocop/Style/StringLiterals:
-        enabled: false
   duplication:
     enabled: true
     config:

--- a/ruby/rails/rubocop-disabled.yml
+++ b/ruby/rails/rubocop-disabled.yml
@@ -19,6 +19,9 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Enabled: false
 
+Metrics/ParameterLists:
+  Enabled: false
+
 Metrics/PerceivedComplexity:
   Enabled: false
 
@@ -26,6 +29,9 @@ Style/Documentation:
   Enabled: false
 
 Style/DotPosition:
+  Enabled: false
+
+Style/StringLiterals:
   Enabled: false
 
 Style/TrailingCommaInLiteral:

--- a/ruby/rails/rubocop-disabled.yml
+++ b/ruby/rails/rubocop-disabled.yml
@@ -1,13 +1,13 @@
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/BlockNesting:
   Enabled: false
 
 Metrics/ClassLength:
-  Enabled: false
-
-Metrics/ModuleLength:
   Enabled: false
 
 Metrics/CyclomaticComplexity:
@@ -16,17 +16,17 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/ModuleLength:
+  Enabled: false
+
 Metrics/PerceivedComplexity:
-  Enabled: false
-
-Metrics/BlockLength:
-  Enabled: false
-
-Style/TrailingCommaInLiteral:
   Enabled: false
 
 Style/Documentation:
   Enabled: false
 
 Style/DotPosition:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
   Enabled: false

--- a/ruby/rails/rubocop-disabled.yml
+++ b/ruby/rails/rubocop-disabled.yml
@@ -25,10 +25,16 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Style/Alias:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 
 Style/DotPosition:
+  Enabled: false
+
+Style/SpaceAroundEqualsInParameterDefault:
   Enabled: false
 
 Style/StringLiterals:


### PR DESCRIPTION
1. Alphabetizes rubocop exclusions
2. Moves rubocop exclusions in `.codeclimate.yml` into the already-existing `rubocop-disabled.yml`
3. Adds exclusions from Jarvis:
    1. Allows spaces around default parameter equals signs
    2. Disables string literal style check (single or double quotes)