### PR TITLE
Enforce Rubocop On Specs

### DIFF
--- a/ruby/rails/rubocop.yml
+++ b/ruby/rails/rubocop.yml
@@ -27,7 +27,6 @@ AllCops:
     - '**/Vagabondfile'
   Exclude:
     - 'vendor/**/*'
-    - 'spec/**/*'
     - 'script/**/*'
   # Default formatter will be used if no -f/--format option is given.
   DefaultFormatter: progress


### PR DESCRIPTION
Disabling the exclusion of rubo cop on specs here so that we can lint our tests.  This will help us write more consistent code.

If this needs to be disabled (I don't think it should) it can be disabled on a per-project basis in the .codeclimate.yml