### PR TITLE
[# 154388686] As a Ruby developer, so that my multiline conditionals are horizontal-space efficient, disable the MultilineOperationIndentation cop

### DIFF
--- a/ruby/rails/rubocop-disabled.yml
+++ b/ruby/rails/rubocop-disabled.yml
@@ -34,18 +34,6 @@ Style/Documentation:
 Style/DotPosition:
   Enabled: false
 
-# Allow formatting like
-#
-#   return some_value if some_really_long_condition_that_eats_up_the_line ||
-#     another_pretty_long_condition_that_would_not_be_readable_if_further_indented
-#
-# instead of requiring formatting like
-#
-#   return some_value if some_really_long_condition_that_eats_up_the_line ||
-#                        another_pretty_long_condition_that_would_not_be_readable_if_further_indented
-Style/MultilineOperationIndentation:
-  Enabled: false
-
 Style/SpaceAroundEqualsInParameterDefault:
   Enabled: false
 

--- a/ruby/rails/rubocop-disabled.yml
+++ b/ruby/rails/rubocop-disabled.yml
@@ -34,6 +34,18 @@ Style/Documentation:
 Style/DotPosition:
   Enabled: false
 
+# Allow formatting like
+#
+#   return some_value if some_really_long_condition_that_eats_up_the_line ||
+#     another_pretty_long_condition_that_would_not_be_readable_if_further_indented
+#
+# instead of requiring formatting like
+#
+#   return some_value if some_really_long_condition_that_eats_up_the_line ||
+#                        another_pretty_long_condition_that_would_not_be_readable_if_further_indented
+Style/MultilineOperationIndentation:
+  Enabled: false
+
 Style/SpaceAroundEqualsInParameterDefault:
   Enabled: false
 

--- a/ruby/rails/rubocop-overrides.yml
+++ b/ruby/rails/rubocop-overrides.yml
@@ -79,6 +79,19 @@ Style/BlockDelimiters:
     - proc
     - it
 
+# Require formatting like
+#
+#   return some_value if some_really_long_condition_that_eats_up_the_line ||
+#     another_pretty_long_condition_that_would_not_be_readable_if_further_indented
+#
+# instead of formatting like
+#
+#   return some_value if some_really_long_condition_that_eats_up_the_line ||
+#                        another_pretty_long_condition_that_would_not_be_readable_if_further_indented
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+  IndentationWidth: 2
+
 # prefer python style default positional arguments
 # def something(default_one='some thing')
 Style/SpaceAroundEqualsInParameterDefault:
@@ -105,4 +118,3 @@ Style/AlignParameters:
   SupportedStyles:
     - with_first_parameter
     - with_fixed_indentation
-


### PR DESCRIPTION
As a Ruby developer, so that my multiline conditionals are horizontal-space efficient, disable the MultilineOperationIndentation cop

[Tracker #154388686](https://www.pivotaltracker.com/story/show/154388686)