### PR TITLE
Remove TargetRubyVersion from rubocop-defaults.yml

### DIFF
--- a/ruby/rails/rubocop-defaults.yml
+++ b/ruby/rails/rubocop-defaults.yml
@@ -60,9 +60,6 @@ AllCops:
   # which is "/tmp" on Unix-like systems, but could be something else on other
   # systems.
   CacheRootDirectory: /tmp
-  # What version of the Ruby interpreter is the inspected code intended to
-  # run on? (If there is more than one, set this to the lowest version.)
-  TargetRubyVersion: 2.1
 
 # Indent private/protected/public as deep as method definitions
 Layout/AccessModifierIndentation:


### PR DESCRIPTION
Setting TargetRubyVersion to 2.1 in this file causes an error in newer Rubocop versions, even if it's overridden elsewhere. Since we do override it for individual repos, we don't need it here anyway.

Here's the error:
```
/usr/local/bundle/gems/rubocop-0.74.0/lib/rubocop/config_validator.rb:98:in `check_target_ruby': RuboCop found unsupported Ruby version 2.1 in `TargetRubyVersion` parameter (in .rubocop-defaults.yml). 2.1-compatible analysis was dropped after version 0.58. (RuboCop::ValidationError)
Supported versions: 2.3, 2.4, 2.5, 2.6, 2.7
```
CC [build](https://codeclimate.com/repos/5d41ea9586bd7a4653000b05/builds/65)